### PR TITLE
Add comparison limit modal when a 4th plan is selected

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1009,6 +1009,58 @@ button.btn-pill-active[data-hover="true"] {
   text-align: center;
 }
 
+/* Comparison limit notice */
+.notice-modal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 400px;
+  margin: 1rem;
+  text-align: center;
+  background-color: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), var(--sheen);
+}
+
+.notice-modal-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  margin-bottom: 0.25rem;
+  border-radius: 9999px;
+  color: var(--accent);
+  background-color: var(--accent-tint);
+  border: 1px solid rgba(168, 95, 46, 0.22);
+}
+
+.notice-modal-title {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--text);
+}
+
+.notice-modal-body {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.notice-modal-hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-subtle);
+}
+
 /*******************/
 /*     FOOTER      */
 /*******************/

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,16 +2,20 @@ import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import "./App.css";
 import NavbarComponent from "./components/NavbarComponent";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import Modal from "./components/Modal";
 import RequestContactForm from "./components/RequestContactForm";
 import RsvpForm from "./components/RsvpForm";
+import ComparisonNoticeModal from "./components/ComparisonNoticeModal";
+import { clearNotice } from "./features/plans/comparedPlansSlice";
 
 function App() {
   const showContactForm = useSelector((state) => state.showContactForm.value);
   const county = useSelector((state) => state.county.value); // selected county value
   const showRsvpForm = useSelector((state) => state.showRsvpForm.value);
   const meeting = useSelector((state) => state.meetingRsvp.value);
+  const comparisonNotice = useSelector((state) => state.comparedPlans.notice);
+  const dispatch = useDispatch();
 
   return (
     <>
@@ -78,6 +82,11 @@ function App() {
       {showRsvpForm && (
         <Modal>
           <RsvpForm />
+        </Modal>
+      )}
+      {comparisonNotice && (
+        <Modal onBackdropClick={() => dispatch(clearNotice())}>
+          <ComparisonNoticeModal />
         </Modal>
       )}
     </>

--- a/frontend/src/components/ComparisonNoticeModal.jsx
+++ b/frontend/src/components/ComparisonNoticeModal.jsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { TriangleAlert } from "lucide-react";
+import ButtonComponent from "./ButtonComponent";
+import { clearNotice } from "../features/plans/comparedPlansSlice";
+
+const ComparisonNoticeModal = () => {
+  const dispatch = useDispatch();
+  const notice = useSelector((state) => state.comparedPlans.notice);
+
+  // Escape dismisses, matching the backdrop click.
+  useEffect(() => {
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") dispatch(clearNotice());
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [dispatch]);
+
+  if (!notice) return null;
+
+  return (
+    <div
+      className="notice-modal p-6"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="comparison-notice-title"
+      aria-describedby="comparison-notice-body"
+    >
+      <div className="notice-modal-icon">
+        <TriangleAlert size={26} strokeWidth={2.25} />
+      </div>
+      <h2 id="comparison-notice-title" className="notice-modal-title">
+        {notice.title}
+      </h2>
+      <p id="comparison-notice-body" className="notice-modal-body">
+        {notice.msg}
+      </p>
+      <p className="notice-modal-hint">
+        Remove a plan from your comparison to make room for another one.
+      </p>
+      {/* autoFocus lands keyboard and screen reader users inside the dialog */}
+      <ButtonComponent
+        autoFocus
+        styling="bg-brand h-11 w-full mt-1"
+        text="Got it"
+        onPress={() => dispatch(clearNotice())}
+      />
+    </div>
+  );
+};
+
+export default ComparisonNoticeModal;

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,11 +1,17 @@
 import { createPortal } from "react-dom";
 
-const Modal = ({ children }) => {
+// onBackdropClick is optional: without it the backdrop stays inert, which
+// is what the contact and RSVP forms rely on.
+const Modal = ({ children, onBackdropClick }) => {
   return (
     <>
       {createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="modal-backdrop" aria-hidden="true" />
+          <div
+            className="modal-backdrop"
+            aria-hidden="true"
+            onClick={onBackdropClick}
+          />
           {children}
         </div>,
         document.body,

--- a/frontend/src/features/plans/comparedPlansSlice.js
+++ b/frontend/src/features/plans/comparedPlansSlice.js
@@ -1,5 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+// Most plans a user may hold in a comparison at once.
+export const MAX_COMPARED_PLANS = 3;
+
 export const comparedPlansSlice = createSlice({
   name: "comparedPlans",
   initialState: {
@@ -12,10 +15,18 @@ export const comparedPlansSlice = createSlice({
     },
     addToPlanComparison: (state, action) => {
       if (state.value.some(plan => plan.id == action.payload.id)) {
-        state.notice = { type: "notice", msg: "Plan is already selected to compare" }
+        state.notice = {
+          type: "duplicate",
+          title: "Plan already added",
+          msg: "Plan is already selected to compare",
+        }
         return;
-      } else if (state.value.length >= 3) {
-        state.notice = { type: "notice", msg: "Only 3 plans can be compared at once." }
+      } else if (state.value.length >= MAX_COMPARED_PLANS) {
+        state.notice = {
+          type: "limit",
+          title: `You can compare up to ${MAX_COMPARED_PLANS} plans`,
+          msg: `Only ${MAX_COMPARED_PLANS} plans can be compared at once.`,
+        }
         return;
       }
       state.value.push(action.payload) 

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -12,7 +12,6 @@ import { setPlans } from "../features/plans/companyPlansSlice";
 import {
   addToPlanComparison,
   removeFromPlanComparison,
-  clearNotice,
   setComparedPlans,
 } from "../features/plans/comparedPlansSlice";
 
@@ -29,9 +28,6 @@ const ExplorePage = () => {
   const companies = useSelector((state) => state.companies.value); // companies in a county value
   const selectedCompany = useSelector((state) => state.selectedCompany.value); // the county the user selects to view their plans
   const companyPlans = useSelector((state) => state.companyPlans.value);
-  const comparisonErrorNotice = useSelector(
-    (state) => state.comparedPlans.notice,
-  );
   const comparedPlans = useSelector((state) => state.comparedPlans.value);
   const [isOctoberYet, setIsOctoberYet] = useState(true);
 
@@ -93,29 +89,19 @@ const ExplorePage = () => {
               <ButtonComponent
                 text="Linn"
                 onPress={() => selectCounty("Linn")}
-                className={
-                  county == `Linn`
-                    ? `btn-pill-active`
-                    : "btn-pill"
-                }
+                className={county == `Linn` ? `btn-pill-active` : "btn-pill"}
               />
               <ButtonComponent
                 text="Tillamook"
                 onPress={() => selectCounty("Tillamook")}
                 className={
-                  county == `Tillamook`
-                    ? `btn-pill-active`
-                    : "btn-pill"
+                  county == `Tillamook` ? `btn-pill-active` : "btn-pill"
                 }
               />
               <ButtonComponent
                 text="Lincoln"
                 onPress={() => selectCounty("Lincoln")}
-                className={
-                  county == `Lincoln`
-                    ? `btn-pill-active`
-                    : "btn-pill"
-                }
+                className={county == `Lincoln` ? `btn-pill-active` : "btn-pill"}
               />
             </div>
           </div>


### PR DESCRIPTION
The 3-plan cap already existed in comparedPlansSlice and set a `notice`, but nothing ever rendered it — ExplorePage selected `comparisonErrorNotice` and dropped it on the floor, so a rejected 4th plan failed silently. This surfaces that notice as a modal.

- New ComparisonNoticeModal renders the notice with an alert icon, the cap in the title, and a "Got it" dismiss that clears it.
- Rendered from App.jsx alongside the contact and RSVP modals, so it covers any page that can add to a comparison.
- Extract MAX_COMPARED_PLANS = 3 and build the title and message from it, so the copy cannot drift from the enforced cap.
- Give notices a `type` and `title`; the duplicate-plan case stays distinct from the limit case.
- Modal takes an optional onBackdropClick. The contact and RSVP forms pass nothing and keep their inert backdrop; only this modal dismisses on backdrop click, and on Escape.
- Remove the two now-superseded dead notice references in ExplorePage. ESLint drops from 16 problems to 14.

Verified the reducer against 16 assertions: the 4th add is rejected with the list intact, dismissing keeps the selection, and removing one makes room again.