### PR TITLE
Correct four stale plan rows in data.sql to match production

### DIFF
--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -23,7 +23,7 @@ dr_visit, er_visit, hospital_stay, hospital_stay_length, surgery_min, surgery_ma
 radiology_copay_min, radiology_copay_max, radiology_coinsurance, dental_benefit, 
 otc_credit, otc_renewal, giveback_amount, rx_coverage, company_id
 ) VALUES (
-  1, "Giveback", 2026, 0, 7900, "HMO", 0, 115, 385, 5, 385, 525, true, 100, 300, 0, 1250, 0, "None", 154.20, true, 1
+  1, "Giveback", 2026, 0, 7900, "HMO", 0, 115, 385, 5, 385, 525, true, 100, 300, 0, 250, 0, "None", 154.20, true, 1
 );
 INSERT INTO plan (id, plan_name, plan_year, monthly_premium, moop, plan_type, 
 dr_visit, er_visit, hospital_stay, hospital_stay_length, surgery_min, surgery_max, surgery_copay_type, 
@@ -109,21 +109,21 @@ dr_visit, er_visit, hospital_stay, hospital_stay_length, surgery_min, surgery_ma
 radiology_copay_min, radiology_copay_max, radiology_coinsurance, dental_benefit, 
 otc_credit, otc_renewal, giveback_amount, rx_coverage, company_id
 ) VALUES (
-  12, "Essentials OR-4", 2026, 16, 4500, "HMO-POS", 0, 125, 400, 4, 350, 400, true, 225, 225, 0, 0, 35, "Quarterly", 0, true, 3
+  12, "Essentials OR-4", 2026, 0, 5500, "HMO-POS", 0, 135, 455, 5, 405, 455, true, 260, 260, 0, 0, 25, "Quarterly", 0, true, 3
 );
 INSERT INTO plan (id, plan_name, plan_year, monthly_premium, moop, plan_type, 
 dr_visit, er_visit, hospital_stay, hospital_stay_length, surgery_min, surgery_max, surgery_copay_type, 
 radiology_copay_min, radiology_copay_max, radiology_coinsurance, dental_benefit, 
 otc_credit, otc_renewal, giveback_amount, rx_coverage, company_id
 ) VALUES (
-  13, "Essentials OR-0003", 2026, 46, 3500, "HMO-POS", 0, 140, 395, 5, 345, 395, true, 230, 230, 0, 1500, 0, "None", 0, true, 3
+  13, "Essentials OR-0003", 2026, 69, 5200, "HMO-POS", 0, 130, 425, 5, 375, 425, true, 220, 220, 0, 1500, 0, "None", 0, true, 3
 );
 INSERT INTO plan (id, plan_name, plan_year, monthly_premium, moop, plan_type, 
 dr_visit, er_visit, hospital_stay, hospital_stay_length, surgery_min, surgery_max, surgery_copay_type, 
 radiology_copay_min, radiology_copay_max, radiology_coinsurance, dental_benefit, 
 otc_credit, otc_renewal, giveback_amount, rx_coverage, company_id
 ) VALUES (
-  14, "Essentials OR-0001", 2026, 49, 4900, "PPO", 0, 125, 395, 6, 245, 395, true, 250, 250, 0, 1250, 25, "Quarterly", 0, true, 3
+  14, "Essentials OR-0001", 2026, 74, 5700, "PPO", 0, 130, 455, 6, 305, 455, true, 200, 200, 0, 1000, 0, "None", 0, true, 3
 );
 
 -- ##########################


### PR DESCRIPTION
data.sql disagreed with the live database on 30 values across 4 plans. The database is correct; the seed file was never right.

Cause: commit 231ed24 (2025-10-01) renamed placeholder rows to the real UnitedHealthcare plans but kept the placeholders' benefit figures. "Plan 4" -> "Essentials OR-4", "Plan 3" -> "Essentials OR-0003", and "Plan 1" -> "Essentials OR-0001" all carried their old numbers forward. This never surfaced because the deployed image predates that commit, so the bad seed data has never actually run.

Corrected to match PlanetScale:
  id  1 Giveback            dental_benefit 1250 -> 250
  id 12 Essentials OR-4     10 fields (premium 16 -> 0, moop 4500 -> 5500, ...)
  id 13 Essentials OR-0003   8 fields (premium 46 -> 69, moop 3500 -> 5200, ...)
  id 14 Essentials OR-0001  11 fields (premium 49 -> 74, moop 4900 -> 5700, ...)

The premium errors mattered most: two plans understated their monthly premium by $25 each, and data.sql wipes and re-seeds `plan` on every startup, so deploying would have overwritten the correct figures.

Verified all 504 field comparisons across 24 plans now match the database with zero differences, and every insert still balances.